### PR TITLE
fixed noUnusedParameters error by prepending _

### DIFF
--- a/src/backend-expectation.ts
+++ b/src/backend-expectation.ts
@@ -51,7 +51,7 @@ export class BackendExpectation {
       expect(connection.request.getBody()).toEqual(stringifyBody(this.options.body), 'Request body mismatch.');
     }
 
-    this.options.headers.forEach((values, name) => {
+    this.options.headers.forEach((_values, name) => {
       expect(connection.request.headers.get(name)).toEqual(this.options.headers.get(name), 'Request header mismatch.');
     });
   }

--- a/src/fake-backend.ts
+++ b/src/fake-backend.ts
@@ -121,7 +121,7 @@ export class FakeBackend extends MockBackend {
       throw new Error('No connections to flush');
     }
 
-    this._connections.forEach((connection, order) => {
+    this._connections.forEach((_connection, order) => {
       this._verifyExpectation(order);
     });
   }


### PR DESCRIPTION
This is useful when `"noUnusedParams": true` in `tsconfig.json` of an `angular-cli` project.